### PR TITLE
docker build files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.*
+docker
+!docker/entrypoint.sh
+doc
+README.md

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:2.7.14-alpine as builder
+
+RUN apk add --no-cache build-base linux-headers python-dev file
+RUN pip install cython==0.27.1
+
+RUN mkdir -p /opt/SwiperProxy
+
+COPY . /opt/SwiperProxy/swiperproxy
+
+WORKDIR /opt/SwiperProxy/swiperproxy/include/streamhtmlparser
+RUN ./configure && make && make install
+
+WORKDIR /opt/SwiperProxy/swiperproxy/include/streamhtmlparser/src/py-streamhtmlparser
+RUN make && make install
+
+
+FROM python:2.7.14-alpine
+
+RUN pip install ipy==0.83
+RUN mkdir -p /var/log/swiperproxy/
+COPY --from=builder /opt/SwiperProxy/swiperproxy /opt/SwiperProxy/swiperproxy
+COPY --from=builder /usr/local/lib/python2.7/site-packages/streamhtmlparser.so /usr/local/lib/python2.7/site-packages/
+COPY --from=builder /usr/local/lib/libstreamhtmlparser.so.0 /usr/local/lib/
+
+COPY docker/entrypoint.sh /entrypoint.sh
+EXPOSE 8080
+EXPOSE 40443
+WORKDIR /opt/SwiperProxy/swiperproxy
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["./Proxy.py", "-c", "proxy.conf"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ Run `build.sh`
 
 You need to specify some environment settings in order for the container to work properly, namely:
 
-* SP_HOST - `hostname` in `proxy.conf`
+* SP_HOSTNAME - `hostname` in `proxy.conf`
 * SP_HTTP_PORT - `http_port` in `proxy.conf`
 * SP_HTTPS_PORT= `https_port` in `proxy.conf`
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,31 @@
+Docker image for swiperproxy
+
+### Building
+
+Run `build.sh`
+
+### Usage
+
+You need to specify some environment settings in order for the container to work properly, namely:
+
+* SP_HOST - `hostname` in `proxy.conf`
+* SP_HTTP_PORT - `http_port` in `proxy.conf`
+* SP_HTTPS_PORT= `https_port` in `proxy.conf`
+
+Example:
+
+```
+docker run -e SP_HOST=proxy.example.org -e SP_HTTP_PORT=80 -e SP_HTTPS_PORT=443 -p80:8080 -p443:40443 swiperproxy/swiperproxy
+```
+
+A self-signed certificate will be generated when the container starts. If you want to use your own, just map it (make sure it contains both private key and certificate as described in documentation):
+
+```
+docker run (...) -v /path/to/certificate.pem:/opt/SwiperProxy/swiperproxy/cert.pem swiperproxy/swiperproxy
+```
+
+You can also mount logs directory to persist them or your own `htdocs` to use instead such as:
+
+```
+docker run (...) -v /path/to/htdocs:/opt/SwiperProxy/swiperproxy/htdocs -v /path/to/logs:/var/log/swiperproxy/ swiperproxy/swiperproxy
+```

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+
+IMAGE="swiperproxy/swiperproxy"
+
+docker build -t $IMAGE -f Dockerfile ..

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ ! -e /opt/SwiperProxy/swiperproxy/cert.pem ]; then
+	apk add --no-cache openssl
+	openssl req -x509 -newkey rsa:4096 -keyout /tmp/key.pem \
+			    -out /tmp/cert.temp.pem -days 365 -nodes \
+			    -subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=www.example.com"
+	cat /tmp/key.pem /tmp/cert.temp.pem > /opt/SwiperProxy/swiperproxy/cert.pem
+fi
+
+# TODO support any proxy.conf element use env vars with same field name with SP_ prefix?
+sed -i "s/^https_certificate=.*/https_certificate=cert.pem/g" /opt/SwiperProxy/swiperproxy/proxy.conf
+sed -i "s/^hostname=.*/hostname=$SP_HOSTNAME/g" /opt/SwiperProxy/swiperproxy/proxy.conf
+sed -i "s/^http_port=.*/http_port=$SP_HTTP_PORT/g" /opt/SwiperProxy/swiperproxy/proxy.conf
+sed -i "s/^https_port=.*/https_port=$SP_HTTPS_PORT/g" /opt/SwiperProxy/swiperproxy/proxy.conf
+sed -i "s/proxy.example.org/$SP_HOSTNAME:$SP_HTTP_PORT/g" /opt/SwiperProxy/swiperproxy/htdocs/index.html
+
+exec "$@"


### PR DESCRIPTION
I hope you find this Dockerfile contribution useful!

`build.sh` is already configured for `swiperproxy/swiperproxy`, assuming you will create a dockerhub account (named `swiperproxy`) 👍 

`entrypoint.sh` could be generalized in order to support customising any entry in proxy.conf but I think it's already useful as it is.

docker/README.md included with some instructions.

Let me know if there's anything else I can add or if you need any help settings dockerhub account for automated builds (in case you are interested)

I've made a branch of `v1.1` tag and built a docker image out of that available in https://hub.docker.com/r/fopina/swiperproxy/

If you start hosting your own, I'll remove this as it's vanilla code :)